### PR TITLE
Enable Netlify deployment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+dist/
+.env

--- a/README.md
+++ b/README.md
@@ -157,6 +157,14 @@ npm start
 - **Railway/Heroku** - Full-stack deployment
 - **VPS/Docker** - Self-hosted deployment
 
+### Deploying to Netlify
+
+1. Push this project to a GitHub repository.
+2. Create an account at [Netlify](https://netlify.com) and click **New site from Git**.
+3. Select your repository and leave the detected settings (`npm run build` and `dist/public`).
+4. Netlify reads `netlify.toml` and builds your app, deploying the API as a serverless function.
+5. After the build finishes, you will get a public URL where the site and API are available.
+
 ## 🤝 Contributing
 
 1. Fork the repository

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,9 @@
+[build]
+  command = "npm run build"
+  publish = "dist/public"
+  functions = "netlify/functions"
+
+[[redirects]]
+  from = "/api/*"
+  to = "/.netlify/functions/server/:splat"
+  status = 200

--- a/netlify/functions/server.ts
+++ b/netlify/functions/server.ts
@@ -1,0 +1,16 @@
+import serverless from 'serverless-http';
+import { createApp } from '../../server/app';
+
+let handlerPromise: Promise<serverless.Handler> | null = null;
+
+function getHandler() {
+  if (!handlerPromise) {
+    handlerPromise = createApp().then(({ app }) => serverless(app));
+  }
+  return handlerPromise;
+}
+
+export const handler: serverless.Handler = async (event, context) => {
+  const h = await getHandler();
+  return h(event, context);
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -72,7 +72,8 @@
         "wouter": "^3.3.5",
         "ws": "^8.18.0",
         "zod": "^3.24.2",
-        "zod-validation-error": "^3.4.0"
+        "zod-validation-error": "^3.4.0",
+        "serverless-http": "^3.4.0"
       },
       "devDependencies": {
         "@replit/vite-plugin-cartographer": "^0.2.7",

--- a/package.json
+++ b/package.json
@@ -74,7 +74,8 @@
     "wouter": "^3.3.5",
     "ws": "^8.18.0",
     "zod": "^3.24.2",
-    "zod-validation-error": "^3.4.0"
+    "zod-validation-error": "^3.4.0",
+    "serverless-http": "^3.4.0"
   },
   "devDependencies": {
     "@replit/vite-plugin-cartographer": "^0.2.7",

--- a/server/app.ts
+++ b/server/app.ts
@@ -1,0 +1,79 @@
+import express, { type Request, type Response, type NextFunction } from "express";
+import { registerRoutes } from "./routes";
+import { log } from "./vite";
+
+export async function createApp() {
+  const app = express();
+
+  // CORS configuration for production deployment
+  app.use((req, res, next) => {
+    const allowedOrigins = [
+      'http://localhost:5000',
+      'http://localhost:3000',
+      'https://securemedia-production.up.railway.app',
+      'https://www.tataplaybinge.com',
+      'https://tb.tapi.videoready.tv'
+    ];
+
+    const origin = req.headers.origin;
+    if (origin && allowedOrigins.includes(origin as string)) {
+      res.setHeader('Access-Control-Allow-Origin', origin as string);
+    }
+
+    res.setHeader('Access-Control-Allow-Methods', 'GET, POST, PUT, DELETE, OPTIONS');
+    res.setHeader('Access-Control-Allow-Headers', 'Content-Type, Authorization, deviceid, referer, user-agent');
+    res.setHeader('Access-Control-Allow-Credentials', 'true');
+
+    if (req.method === 'OPTIONS') {
+      res.sendStatus(200);
+      return;
+    }
+
+    next();
+  });
+
+  app.use(express.json());
+  app.use(express.urlencoded({ extended: false }));
+
+  app.use((req, res, next) => {
+    const start = Date.now();
+    const path = req.path;
+    let capturedJsonResponse: Record<string, any> | undefined;
+
+    const originalResJson = res.json;
+    res.json = function (bodyJson, ...args) {
+      capturedJsonResponse = bodyJson;
+      return originalResJson.apply(res, [bodyJson, ...args]);
+    };
+
+    res.on("finish", () => {
+      const duration = Date.now() - start;
+      if (path.startsWith("/api")) {
+        let logLine = `${req.method} ${path} ${res.statusCode} in ${duration}ms`;
+        if (capturedJsonResponse) {
+          logLine += ` :: ${JSON.stringify(capturedJsonResponse)}`;
+        }
+
+        if (logLine.length > 80) {
+          logLine = logLine.slice(0, 79) + "…";
+        }
+
+        log(logLine);
+      }
+    });
+
+    next();
+  });
+
+  const server = await registerRoutes(app);
+
+  app.use((err: any, _req: Request, res: Response, _next: NextFunction) => {
+    const status = err.status || err.statusCode || 500;
+    const message = err.message || "Internal Server Error";
+
+    res.status(status).json({ message });
+    throw err;
+  });
+
+  return { app, server };
+}

--- a/server/index.ts
+++ b/server/index.ts
@@ -1,92 +1,16 @@
-import express, { type Request, Response, NextFunction } from "express";
-import { registerRoutes } from "./routes";
 import { setupVite, serveStatic, log } from "./vite";
-
-const app = express();
-
-// CORS configuration for production deployment
-app.use((req, res, next) => {
-  const allowedOrigins = [
-    'http://localhost:5000',
-    'http://localhost:3000', 
-    'https://securemedia-production.up.railway.app',
-    'https://www.tataplaybinge.com',
-    'https://tb.tapi.videoready.tv'
-  ];
-  
-  const origin = req.headers.origin;
-  if (allowedOrigins.includes(origin as string)) {
-    res.setHeader('Access-Control-Allow-Origin', origin as string);
-  }
-  
-  res.setHeader('Access-Control-Allow-Methods', 'GET, POST, PUT, DELETE, OPTIONS');
-  res.setHeader('Access-Control-Allow-Headers', 'Content-Type, Authorization, deviceid, referer, user-agent');
-  res.setHeader('Access-Control-Allow-Credentials', 'true');
-  
-  if (req.method === 'OPTIONS') {
-    res.sendStatus(200);
-    return;
-  }
-  
-  next();
-});
-
-app.use(express.json());
-app.use(express.urlencoded({ extended: false }));
-
-app.use((req, res, next) => {
-  const start = Date.now();
-  const path = req.path;
-  let capturedJsonResponse: Record<string, any> | undefined = undefined;
-
-  const originalResJson = res.json;
-  res.json = function (bodyJson, ...args) {
-    capturedJsonResponse = bodyJson;
-    return originalResJson.apply(res, [bodyJson, ...args]);
-  };
-
-  res.on("finish", () => {
-    const duration = Date.now() - start;
-    if (path.startsWith("/api")) {
-      let logLine = `${req.method} ${path} ${res.statusCode} in ${duration}ms`;
-      if (capturedJsonResponse) {
-        logLine += ` :: ${JSON.stringify(capturedJsonResponse)}`;
-      }
-
-      if (logLine.length > 80) {
-        logLine = logLine.slice(0, 79) + "…";
-      }
-
-      log(logLine);
-    }
-  });
-
-  next();
-});
+import { createApp } from "./app";
 
 (async () => {
-  const server = await registerRoutes(app);
+  const { app, server } = await createApp();
 
-  app.use((err: any, _req: Request, res: Response, _next: NextFunction) => {
-    const status = err.status || err.statusCode || 500;
-    const message = err.message || "Internal Server Error";
-
-    res.status(status).json({ message });
-    throw err;
-  });
-
-  // importantly only setup vite in development and after
-  // setting up all the other routes so the catch-all route
-  // doesn't interfere with the other routes
+  // only setup vite in development
   if (app.get("env") === "development") {
     await setupVite(app, server);
   } else {
     serveStatic(app);
   }
 
-  // ALWAYS serve the app on port 5000
-  // this serves both the API and the client.
-  // It is the only port that is not firewalled.
   const port = 5000;
   server.listen({
     port,


### PR DESCRIPTION
## Summary
- refactor express app into `createApp` for reuse
- add Netlify function wrapper and config
- document deployment steps in README
- ignore build artifacts and node_modules
- add `serverless-http` dependency for serverless environments

## Testing
- `npm run check` *(fails: Cannot find type definition file for 'node')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68724d8dbfa8832a94e5850b2943aeec